### PR TITLE
Python 코드에서 `else-return` 패턴 허용 제안

### DIFF
--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -51,6 +51,7 @@ disable=
   too-few-public-methods,
   bad-continuation,
   logging-fstring-interpolation,
+  no-else-return,
   fixme,
 
 


### PR DESCRIPTION
현재 Pylint 설정에서 `else-return`을 막아둔 상태인데, 이를 허가하는 걸 제안합니다.

__A__
```python
if X:
    return A
return B
```

__B__
```python
if X:
    return A
else:
    return B
```

기존 설정은 __B__ 형태의 코드를 막고 __A__ 형태의 코드로 강제하는 설정인데, 저는 경우에 따라 __B__ 형태의 코드가 더 잘 읽힌다고 생각하여 `else-return`을 허용했으면 합니다. 제가 생각하는 `else-return`이 갖는 장점은 다음과 같습니다.

1. 각 조건(상황)에 따라 어떤 값이 결정되는지 한 눈에 알기 쉽습니다. 위 예시에서 `X`가 아닌 상황에 `B`가 반환된다는 사실을 알기 위해서는 (조금 과장하자면) 제어문의 흐름을 파악해야하기 때문에 좀 더 명시적인 형태가 가독성이 좋다고 생각합니다.
1. 그러한 상황에 `return A if X else B` 라고 적으면 되지 않느냐?는 물음에 답하자면...
    1. `A`와 `B`가 조금 길 경우 (예. `return SomeClass(a, b, c) if X else OtherClass(a, b)`) 이러한 패턴은 가독성이 그리 좋지 않을 수 있습니다.
    2. 마찬가지로 `X`가 조금 복잡하거나 내용이 둘 이상일 경우에는 비슷하게 가독성이 떨어지는 것 같습니다.
1. 물론 이 제안은 모든 상황에 `else` 내부에 `return`을 적자는 제안은 아닙니다. `else`의 내용이 길어지거나 복잡해지는 건 피해야한다고 생각합니다.

자유롭게 의견 주세용~ 😅 