### PR TITLE
Add package import rule in python

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -155,6 +155,10 @@ amounts = list(map(labmda a: a.value, filter(None, amounts)))
 
 * [pipenv](https://github.com/pypa/pipenv): 의존성을 관리하기 위한 도구 중 하나입니다. 가상환경 생성, lock 파일을 통한 의존성 관리가 가능하고 `pipenv lock -r > requirements.txt`와 같이 하위호환성도 유지할 수 있습니다. "pipenv만 쓰자!"가 아닌 의존성 관리 도구 중 하나로 소개하고 개인의 판단에 따라 사용합니다.
 
+### Package import 규칙
+
+같은 패키지 내에선 상대경로를, 다른 Package에 있는 것을 import 할 땐 절대경로를 사용합니다.
+
 ## Sanic
 
 ### 204 No Content

--- a/python/README.md
+++ b/python/README.md
@@ -157,7 +157,7 @@ amounts = list(map(labmda a: a.value, filter(None, amounts)))
 
 ### Package import 규칙
 
-같은 패키지 내에선 상대경로를, 다른 Package에 있는 것을 import 할 땐 절대경로를 사용합니다.
+하위 패키지는 상대 경로를, 상위 패키지는 절대 경로를 이용해 import합니다.
 
 ## Sanic
 

--- a/python/README.md
+++ b/python/README.md
@@ -157,7 +157,7 @@ amounts = list(map(labmda a: a.value, filter(None, amounts)))
 
 ### Package import 규칙
 
-하위 패키지는 상대 경로를, 상위 패키지는 절대 경로를 이용해 import합니다.
+절대 경로를 이용해 import 합니다. 단, 편의에 따라 하위 패키지는 상대 경로를 사용할 수 있습니다.
 
 ## Sanic
 


### PR DESCRIPTION
"스타일가이드로 정해진 규칙은 없고 다만 한 레포에서 절대참조 혹은 상대참조 둘 중 하나로 통일하길 권장하고있습니다." 라는 리뷰를 종종 받습니다.

해서
```
같은 패키지 내에선 상대경로를, 다른 Package에 있는 것을 import 할 땐 절대경로를 사용합니다.
```

라는 Package import 룰 관련 StyleGuide 제안드립니다.


---

토의를 통해 아래와 같이 수정하기로 결정되었습니다. 감사합니다.
```
절대 경로를 이용해 import 합니다. 단, 편의에 따라 하위 패키지는 상대 경로를 사용할 수 있습니다.
```