### PR TITLE
Loose Wrapping Condition for Annotation

### DIFF
--- a/android/CodeStyle.xml
+++ b/android/CodeStyle.xml
@@ -477,8 +477,8 @@
   </codeStyleSettings>
   <codeStyleSettings language="kotlin">
     <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
-    <option name="PARAMETER_ANNOTATION_WRAP" value="2" />
-    <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="VARIABLE_ANNOTATION_WRAP" value="1" />
     <indentOptions>
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
     </indentOptions>


### PR DESCRIPTION
### Summary

팀 논의를 통해 Kotlin Annotation Wrap 조건을 완화합니다.
`wrap always` => `wrap if long`